### PR TITLE
Arkansas Postal Abbreviation: AR

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The site that no one needed:
 |416 | |**Request Range Not Satisfiable** Toronto, ON|
 |417 | <img src ="images/417.gif" width=200> |**Expectation Failed** SW Missouri|
 |418 |<img src ="images/418.jpg" width=200> |**I am a teapot** Quebec, QC|
-|501 |<img src ="images/501.png" width=200> |**Not Implemented** Little Rock, AK|
+|501 |<img src ="images/501.png" width=200> |**Not Implemented** Little Rock, AR|
 |502 |<img src ="images/502.png" width=200> |**Bad Gateway** Louisville, KY|
 |503 |<img src ="images/503.png" width=200> |**Service Unavailable** Portland, OR|
 |504|<img src ="images/504.png" width=200> |**Gateway Timeout** New Orleans, LA|


### PR DESCRIPTION
⚛👋 Hello there! Welcome. Please follow the steps below to tell us about your contribution.

### Requirements for Contributing a Bug Fix


### Identify the Bug

Per: https://faq.usps.com/s/article/What-are-the-USPS-abbreviations-for-U-S-states-and-territories

Alaska - AK
Arkansas - AR


### Description of the Change

Updates Postal Abbreviation listed for "Little Rock, AK" to "Little Rock, AR" - matching the state in which the `City of Little Rock` resides, and therefore Reality.

### Alternate Designs

Moving the `City of Little Rock` to Alaska would likely incur several million dollars of Transportation fees, which I cannot afford.

### Possible Drawbacks

Having to live in Little Rock probably sucks?

### Verification Process

I used to live in Arkansas.

### Release Notes

"Correct State Abbreviation for City of Little Rock"